### PR TITLE
Clarifications and dead game fix

### DIFF
--- a/english.md
+++ b/english.md
@@ -143,6 +143,10 @@ It can happen that a game becomes stuck and no more progress is made. A player
 can offer the other one a remis, if the other player accepts the game ends in a
 draw.
 
+If a state is repeated more than once across turns, any player can immediately
+force a remis. The state of a game is the entirety of the positions and
+orientations of all cards.
+
 ##Edgecases
 Since turning around the discard stack and subsequently taking a card from the
 main stack is considered a single action, merely turning around the discard
@@ -150,9 +154,9 @@ stack is knockable. It usually is anyways because touching the discard stack is
 knockable unless the required action is moving a card from the stack to a final
 stack.
 
-If the active player has a single card left in their own stacks, and moving it
-either to the board in general, or not moving it to a final stack is knockable,
-and the passive player knocks, the card is returned to the originating stack.
+Even an action that would normally end the game is knockable, if it would be
+knockable under normal conditions, too. In that case, the action is undone, if
+applicable, and it is the knocking player's turn.
 
 If there are no cards in the side stack left, no cards can be put on it anymore.
 

--- a/german.md
+++ b/german.md
@@ -151,6 +151,10 @@ Es kann passieren, dass ein Spiel keinen Fortschritt mehr macht. Eine Spielerin
 kann dann der anderen ein Remis anbieten, wenn die andere Spielerin akzeptiert,
 endet das Spiel in einem Unentschieden.
 
+Wiederholt sich ein Zustand mehr als einmal über einen Zug hinaus, kann jede
+Spielerin sofort ein Remis einfordern. Der Zustand eines Spiels ist die
+Gesamtheit der Positionen und Orientierungen aller Karten.
+
 ##Härtefälle
 Da das Umdrehen des Ablagestapels und das darauffolgende Nehmen einer Karte vom
 Hauptstapel als eine einzige Aktion betrachtet wird, ist selbst das Umdrehen
@@ -158,10 +162,9 @@ des Ablagestapels klopfbar. Normalerweise ist es das sowieso, da das Berühren
 des Ablagestapels klopfbar ist, wenn die erforderte Aktion nicht das Bewegen
 einer Karte vom Ablagestapel zu einem Endstapel ist.
 
-Wenn die aktive Spielerin nur noch eine Karte in ihren eigenen Stapeln hat, und
-entweder das Bewegen dieser Karte zum Feld allgemein, oder das Nicht-Bewegen
-der Karte zu eiem Endstapel klopfbar ist, und die passive Spielerin klopft,
-wird die Karte zurück auf den ursprünglichen Stapel gelegt.
+Auch eine eigentlich spielbeendende Aktion ist klopfbar, wenn sie es
+normalerweise ebenfalls wäre. Die Aktion wird in dem Fall dann gegebenenfalls
+rückgangig gemacht, und die klopfende Spielerin ist am Zug.
 
 Wenn keine Karten im Seitenstapel übrig sind, können keine Karten mehr auf ihn
 gelegt werden.


### PR DESCRIPTION
This pull request contains:

- Clarification on the knocking-after-the-last-move rule
- Introduction of a rule that can force a remis when the game is "obviously" stuck. This is done through the introduction of the concept of a "state", as described in the changed files.